### PR TITLE
Send "\n" instead of "C-l" to redisplay prompt

### DIFF
--- a/sbt-mode.el
+++ b/sbt-mode.el
@@ -118,7 +118,7 @@ region are not sent."
           (inhibit-read-only t))
       (ignore-errors (compilation-forget-errors))
       (erase-buffer)
-      (ignore-errors (comint-send-string proc (kbd "C-l"))))))
+      (ignore-errors (comint-send-string proc "\n")))))
 
 (defun sbt:command (command)
   (unless command (error "Please specify a command"))


### PR DESCRIPTION
This fixes #5 for me, but has the drawback of leaving an empty line at the stop of the cleared `*sbt*` buffer. Not sure how to improve this.