### PR TITLE
Adapt `sbt:prompt-regexp` to allow project prompts

### DIFF
--- a/sbt-mode-comint.el
+++ b/sbt-mode-comint.el
@@ -25,7 +25,7 @@ as the comint-input-ring on console start-up"
   :type 'string
   :group 'sbt)
 
-(defcustom sbt:sbt-prompt-regexp "^>[ ]*"
+(defcustom sbt:sbt-prompt-regexp "^\\(\\[[^\]]*\\] \\)?[>$][ ]*"
   "A regular expression to match sbt REPL prompt"
   :type 'string
   :group 'sbt)
@@ -40,7 +40,7 @@ as the comint-input-ring on console start-up"
   :type 'string
   :group 'sbt)
 
-(defcustom sbt:prompt-regexp "^\\(\\(scala\\)?>\\|[ ]+|\\)[ ]*"
+(defcustom sbt:prompt-regexp "^\\(\\(scala\\|\\[[^\]]*\\] \\)?[>$]\\|[ ]+|\\)[ ]*"
   "A regular expression to match sbt and scala console prompts"
   :type 'string
   :group 'sbt)
@@ -194,7 +194,10 @@ line.")
   (let ((point (point))
         (beg (save-excursion (comint-goto-process-mark)
                              (point)))
-        (end (max (point) (save-excursion (end-of-line)(skip-chars-backward " \t\n\r")(point))))
+        (end (max (point)
+                  (save-excursion (end-of-line)
+                                  (skip-chars-backward " \t\n\r")
+                                  (point))))
         mid)
     (goto-char beg)
     (beginning-of-line)


### PR DESCRIPTION
Adapt `sbt:prompt-regexp` and `sbt:sbt-prompt-regexp`

Previously the two variables only consider sbt prompts like:

```
> <text>
```

which breaks in projects with subprojects, where the prompt looks like this:

```
[myproject] $ <text>
```

In this case neither M-n/M-p nor tab completion worked.  With the change
to the regexps it works.

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)