### PR TITLE
support scalatest 3.0 test failure messages

### DIFF
--- a/sbt-mode.el
+++ b/sbt-mode.el
@@ -220,7 +220,9 @@ buffer called *sbt*projectdir."
    '(("^\\[error][[:space:]]\\([/[:word:]]:?[^:[:space:]]+\\):\\([[:digit:]]+\\):" 1 2 nil 2 1)
      ("^\\[warn][[:space:]]\\([/[:word:]]:?[^:[:space:]]+\\):\\([[:digit:]]+\\):" 1 2 nil 1 1)
      ("^\\[info][[:space:]]\\([/[:word:]]:?[^:[:space:]]+\\):\\([[:digit:]]+\\):" 1 2 nil 0 1)
-     ("^\\[info][[:space:]]-[[:space:]]\\(.*\\) \\*\\*\\* FAILED \\*\\*\\*" nil nil nil 2 1)))
+     ;; could be improved
+     ;; https://github.com/scalatest/scalatest/issues/630#issuecomment-223758829
+     ("^\\[info][[:space:]]+\\(.*\\) (\\([^:[:space:]]+\\):\\([^:[:space:]]+\\))" 2 3 nil 2 1)))
   (setq-local
    compilation-mode-font-lock-keywords
    '(("^\\[error] \\(Failed: Total .*\\)"


### PR DESCRIPTION
yeah, so "not a priority" turned into "oooh, that'd be nice" close #62 

this removes support for our hacky "jump to failed test" that didn't know where to go, but I think it's worth it... that was always a very confusing, partial, feature.