### PR TITLE
Error message jumps to proper location instead beginning of line

### DIFF
--- a/sbt-mode.el
+++ b/sbt-mode.el
@@ -266,6 +266,25 @@ buffer called *sbt*projectdir."
     map)
   "Basic mode map for `sbt-start'")
 
+(defun sbt:compilation-parse-errors (start end &rest rules)
+  "Since with compile.el it is impossible to parse scalac error message
+with column information (since column indicator is on different line
+then file name and row), we are going to use this :after advice for parsing
+scalac output and update `compilation-message's in sbt buffer accordingly."
+  (when (string-prefix-p sbt:buffer-name-base (buffer-name))
+    (progn
+      (goto-char start)
+      (beginning-of-line)
+      (while (re-search-forward "^\\[error][[:space:]]+^$" end t)
+        (save-match-data
+          (let* ((error-column (current-column))
+                 (compilation-message-location (previous-single-property-change (point) 'compilation-message))
+                 (compilation-message-property (get-text-property (1- compilation-message-location) 'compilation-message))
+                 (compilation-message-loc (compilation--message->loc compilation-message-property)))
+            ;; update only `compilation-message-loc' which do not have column information already
+            (when (null (car compilation-message-loc))
+              (setcar compilation-message-loc (- error-column 8)))))))))
+
 (define-derived-mode sbt-mode comint-mode "sbt"
   "Major mode for `sbt-start'.
 
@@ -273,7 +292,8 @@ buffer called *sbt*projectdir."
   (use-local-map sbt:mode-map)
   (ignore-errors (scala-mode:set-scala-syntax-mode))
   (add-hook 'sbt-mode-hook 'sbt:initialize-for-comint-mode)
-  (add-hook 'sbt-mode-hook 'sbt:initialize-for-compilation-mode))
+  (add-hook 'sbt-mode-hook 'sbt:initialize-for-compilation-mode)
+  (advice-add 'compilation-parse-errors :after #'sbt:compilation-parse-errors))
 
 (provide 'sbt-mode)
 ;;; sbt-mode.el ends here


### PR DESCRIPTION
When sbt output is parsed compilation-messages are missing column number as scalac output is not providing column information on the same line as file path and row.

This is attempt to retrospectively update compilation-messages with missing column number so navigation to error jumps to proper location instead beginning of line. I was trying to use `compile.el` facility but without success (there is undocumented hook, but it cannot be used for this purpose).

Solution in this PR is using `:after` advice on `compilation-parse-errors`.