### PR TITLE
signal an error on missing SBT build spec file

### DIFF
--- a/sbt-mode.el
+++ b/sbt-mode.el
@@ -127,6 +127,11 @@ subsequent call to this function may provide additional input."
 (defun sbt:command (command &optional focus)
   (unless command (error "Please specify a command"))
 
+  (unless (sbt:find-root)
+    (error (concat "You're not in an sbt project.  "
+		   "Maybe build.sbt or build.scala is missing?  "
+		   "See http://ensime.org/build_tools")))
+
   (when (not (comint-check-proc (sbt:buffer-name)))
     (sbt:run-sbt))
 


### PR DESCRIPTION
The commit adds a more helpful error message for the user who:

1. Creates a "project" by just putting some scala files in a directory
   or under the classic `src/main/scala` and `src/test/scala` paths
2. Starts `sbt` and runs the `ensimeConfig` command (which works)
3. Starts ENSIME (`M-x ensime`)
4. Writes some code, then tries to run any sbt command,
   e.g. `ensime-sbt-do-compile`.  At this point, before the commit, Emacs just
   muttered `wrong-type-argument stringp nil` and retreated to a
   puzzling silence.

Now, please correct me if I'm wrong: adding another such check right after the connection to the ENSIME server doesn't make a lot of sense because it wouldn't make any sense for users of build tools other than sbt. Is this right?