### PR TITLE
Fix package about cl-lib and minimum Emacs version

### DIFF
--- a/sbt-mode-buffer.el
+++ b/sbt-mode-buffer.el
@@ -63,8 +63,8 @@ When run in buffer with no scala project then based on number of sbt buffers thi
 	   (if (eq 1 (length root-and-buffers))
 	       (cdar root-and-buffers)
 	     ;; we have more than one sbt process running, let user choose which one to switch to
-	     (let ((sbt-projects (loop for (key . value) in root-and-buffers
-				       collect key)))
+	     (let ((sbt-projects (cl-loop for (key . value) in root-and-buffers
+					  collect key)))
 	       (cdr (assoc
 		     (if (fboundp 'ido-completing-read)
 			 (ido-completing-read "Switch to sbt buffer for project: " sbt-projects)

--- a/sbt-mode-buffer.el
+++ b/sbt-mode-buffer.el
@@ -3,7 +3,7 @@
 ;; Copyright(c) 2013 Heikki Vesalainen
 ;; For information on the License, see the LICENSE file
 
-(eval-when-compile (require 'cl)) ;; only need cl macros
+(require 'cl-lib)
 
 (require 'sbt-mode-vars)
 (require 'sbt-mode-project)

--- a/sbt-mode-comint.el
+++ b/sbt-mode-comint.el
@@ -3,7 +3,7 @@
 ;; Copyright(c) 2013 Heikki Vesalainen
 ;; For information on the License, see the LICENSE file
 
-(eval-when-compile (require 'cl)) ;; only need cl macros
+(require 'cl-lib)
 (require 'comint)
 (require 'sbt-mode-vars)
 (require 'sbt-mode-project)

--- a/sbt-mode-hydra.el
+++ b/sbt-mode-hydra.el
@@ -105,17 +105,17 @@ to run in `after-save-hook' which will run last sbt command in sbt buffer."
 (defun sbt-hydra:sbt-buffer ()
   (let* ((current-sbt-root (sbt:find-root))
          (root-and-buffers
-          (loop for process being the elements of (process-list)
-                for current-process-buffer = (process-buffer process)
-                when (and
-                      (bufferp current-process-buffer) ;; process must have associated buffer
-                      (with-current-buffer current-process-buffer
-                        (and
-                         (sbt:mode-p)
-                         (process-live-p process)
-                         (equal current-sbt-root (sbt:find-root)))))
-                collect current-process-buffer into file-buffers
-                finally return file-buffers)))
+          (cl-loop for process being the elements of (process-list)
+                   for current-process-buffer = (process-buffer process)
+                   when (and
+                         (bufferp current-process-buffer) ;; process must have associated buffer
+                         (with-current-buffer current-process-buffer
+                           (and
+                            (sbt:mode-p)
+                            (process-live-p process)
+                            (equal current-sbt-root (sbt:find-root)))))
+                   collect current-process-buffer into file-buffers
+                   finally return file-buffers)))
     (car root-and-buffers)))
 
 (defmacro sbt-hydra:with-sbt-buffer (body)

--- a/sbt-mode.el
+++ b/sbt-mode.el
@@ -5,7 +5,7 @@
 ;; Homepage: https://github.com/ensime/emacs-sbt-mode
 ;; Keywords: languages
 ;; Package-Version:  0.2
-;; Package-Requires: ()
+;; Package-Requires: ((emacs "24.4"))
 
 ;;; Commentary:
 ;;


### PR DESCRIPTION
- Specify minimum Emacs version for using `advice-add`(It was provided since 24.4)
- Use cl-lib instead of cl.el(cl-lib was bundled since 24.3)