### PR TITLE
Check process status and if buffer exists when switching to sbt buffer

### DIFF
--- a/sbt-mode-buffer.el
+++ b/sbt-mode-buffer.el
@@ -42,7 +42,9 @@ When run in buffer with no scala project then based on number of sbt buffers thi
 	 (cl-loop for process being the elements of (process-list)
 	       for current-process-buffer = (process-buffer process)
 	       when (and
+		     (equal (process-status process) 'run) ;; proces must be running
 		     (bufferp current-process-buffer) ;; process must have associated buffer
+		     (buffer-live-p current-process-buffer) ;; buffer must not be killed
 		     (with-current-buffer current-process-buffer
 		       (and
 			(sbt:mode-p)

--- a/sbt-mode-hydra.el
+++ b/sbt-mode-hydra.el
@@ -108,7 +108,9 @@ to run in `after-save-hook' which will run last sbt command in sbt buffer."
           (cl-loop for process being the elements of (process-list)
                    for current-process-buffer = (process-buffer process)
                    when (and
+                         (equal (process-status process) 'run) ;; proces must be running
                          (bufferp current-process-buffer) ;; process must have associated buffer
+                         (buffer-live-p current-process-buffer) ;; buffer must not be killed
                          (with-current-buffer current-process-buffer
                            (and
                             (sbt:mode-p)


### PR DESCRIPTION
This PR prevents error:

```
save-current-buffer: Selecting deleted buffer
```

when switching to SBT buffer (as part of `sbt-hydra:hydra` command) when there exists various other processes (and optionally their buffers) in various states.