### PR TITLE
Don't use sbt:get-previous-command in hydra

### DIFF
--- a/sbt-mode-hydra.el
+++ b/sbt-mode-hydra.el
@@ -328,11 +328,11 @@ x - clean        - reset substring (-- -z) to empty string
 
 (defun sbt-hydra:run-previous-sbt-command ()
   (sbt-switch-to-active-sbt-buffer)
-  (sbt:command (sbt:get-previous-command)))
+  (sbt:command sbt-hydra:hydra-previous-command))
 
 (defun sbt-hydra:edit-and-run-previous-sbt-command ()
   (sbt-switch-to-active-sbt-buffer)
-  (sbt:command (read-from-minibuffer "Edit sbt command: " (sbt:get-previous-command))))
+  (sbt:command (read-from-minibuffer "Edit sbt command: " sbt-hydra:hydra-previous-command)))
 
 (defun sbt-hydra:should-text-from-sbt-output ()
   (let ((current-line (thing-at-point 'line)))


### PR DESCRIPTION
Use hydra's own `sbt-hydra:hydra-previous-command` variable instead.

(Making `sbt:get-previous-command` not to remember non-interactive commands did broke hydra automatic execution of previous command on save)