### PR TITLE
Added support for sbt-revolver plugin

### DIFF
--- a/sbt-mode-hydra.el
+++ b/sbt-mode-hydra.el
@@ -615,7 +615,9 @@ x - clean        - reset substring (-- -z) to empty string
     (setq sbt-hydra:jetty-projects jetty-projects)
     (setq sbt-hydra:revolver-projects revolver-projects)
 
-    project-names))
+    (if sbt-hydra:projects
+        sbt-hydra:projects
+      project-names)))
 
 (defun sbt-hydra:projects-for-plugin (sbt-output plugin)
   (if (string-match (format "^[[:space:]]*%s: enabled in \\(.*\\)$" plugin) sbt-output)
@@ -625,7 +627,7 @@ x - clean        - reset substring (-- -z) to empty string
 (defun sbt-hydra:create-hydra ()
   "Create hydras for current scala project. It will create one hydra for every sbt project.
 List of sbt projects is determined in two ways:
- - automatically by running `projects' command in sbt shell which will provide list all available projects.
+ - automatically by running `plugins' command in sbt shell which will provide list of all plugins and projects they are enabled in.
  - by specifying projects in a `dir-locals-file'. This will provide option to specify only subset of all projects available in sbt build.
 The easiest way to use second option is by running `add-dir-local-variable' command while in sbt buffer:
    M-x add-dir-local-variable RET sbt-mode RET sbt-hydra:projects RET (\"proj1\" \"proj2\")"
@@ -638,19 +640,15 @@ The easiest way to use second option is by running `add-dir-local-variable' comm
               (progn
                 ;; Existing sbt buffer
                 (hack-dir-local-variables-non-file-buffer)
-                (if sbt-hydra:projects
-                    (sbt-hydra:generate-hydras-from-projects sbt-hydra:projects)
-                  (add-hook 'comint-output-filter-functions 'sbt-hydra:parse-plugins-info)
-                  (sbt:command "plugins")))
+                (add-hook 'comint-output-filter-functions 'sbt-hydra:parse-plugins-info)
+                (sbt:command "plugins"))
             (let ((sbt:clear-buffer-before-command nil))
               ;; New sbt buffer
               (sbt:run-sbt)
               (sbt-switch-to-active-sbt-buffer)
               (hack-dir-local-variables-non-file-buffer)
-              (if sbt-hydra:projects
-                  (sbt-hydra:generate-hydras-from-projects sbt-hydra:projects)
-                (sbt:command "plugins")
-                (add-hook 'comint-output-filter-functions 'sbt-hydra:parse-plugins-info-skip-init))))))
+              (sbt:command "plugins")
+              (add-hook 'comint-output-filter-functions 'sbt-hydra:parse-plugins-info-skip-init)))))
     "Not in sbt project. Hydra can be generated only from sbt project. See `sbt:find-root' to get more informations."))
 
 (defun sbt-hydra:parse-main-class (sbt-output)


### PR DESCRIPTION
* support for `sbt-revolver` plugin
* fix when specifying `javaOptions` for projects containing `-` in the name
* information about projects is now collected even when projects are specified explicitly by `sbt-hydra:projects`