### PR TITLE
Add sbt:program-options

### DIFF
--- a/sbt-mode-vars.el
+++ b/sbt-mode-vars.el
@@ -14,6 +14,11 @@
   :type 'string
   :group 'sbt)
 
+(defcustom sbt:program-options nil
+  "Options passed to sbt by the `sbt:run-sbt' command."
+  :type '(repeat string)
+  :group 'sbt)
+
 (defcustom sbt:default-command "test:compile"
   "The default command to run with sbt-command."
   :type 'string

--- a/sbt-mode.el
+++ b/sbt-mode.el
@@ -174,15 +174,14 @@ interrupting triggered execution, such as ~compile."
 buffer called *sbt*projectdir."
   (let* ((project-root (or (sbt:find-root)
 			   (error "Could not find project root, type `C-h f sbt:find-root` for help.")))
-         (sbt-command-line (split-string sbt:program-name " "))
          (buffer-name (sbt:buffer-name))
          (inhibit-read-only 1))
     ;; (when (null project-root)
     ;;   (error "Could not find project root, type `C-h f sbt:find-root` for help."))
 
-    (when (not (or (executable-find (nth 0 sbt-command-line))
-                   (file-executable-p (concat project-root (nth 0 sbt-command-line)))))
-      (error "Could not find %s in %s or on PATH. Please customize the sbt:program-name variable." (nth 0 sbt-command-line) project-root))
+    (when (not (or (executable-find sbt:program-name)
+                   (file-executable-p (concat project-root sbt:program-name))))
+      (error "Could not find %s in %s or on PATH. Please customize the sbt:program-name variable." sbt:program-name project-root))
 
     ;; kill existing sbt
     (when (and kill-existing-p (get-buffer buffer-name))
@@ -206,7 +205,7 @@ buffer called *sbt*projectdir."
         (insert (concat "Running " sbt:program-name "\n"))
         (goto-char (point-min))
         (ignore-errors (compilation-forget-errors))
-        (comint-exec (current-buffer) buffer-name (nth 0 sbt-command-line) nil (cdr sbt-command-line)))
+        (comint-exec (current-buffer) buffer-name sbt:program-name nil sbt:program-options))
       (current-buffer))))
 
 (defun sbt:set-opts ()


### PR DESCRIPTION
Fix #79 by introducing `sbt:program-options`.

This will break sbt-mode users who have modified `sbt-program-name` to include arguments for sbt.