### PR TITLE
Fix missing parenthesis in define-derived-mode

### DIFF
--- a/sbt-mode.el
+++ b/sbt-mode.el
@@ -247,7 +247,7 @@ buffer called *sbt*projectdir."
   (use-local-map sbt:mode-map)
   (ignore-errors (scala-mode:set-scala-syntax-mode))
   (add-hook 'sbt-mode-hook 'sbt:initialize-for-comint-mode)
-  (add-hook 'sbt-mode-hook 'sbt:initialize-for-compilation-mode)
+  (add-hook 'sbt-mode-hook 'sbt:initialize-for-compilation-mode))
 
 (provide 'sbt-mode)
 ;;; sbt-mode.el ends here


### PR DESCRIPTION
This fixes a syntax error introduced in https://github.com/ensime/emacs-sbt-mode/pull/127 where the closing parenthesis of `define-derived-mode` was dropped.