### PR TITLE
Restore completion behavior in REPL for scala 2.11 and 2.12, will not…

### DIFF
--- a/sbt-mode-comint.el
+++ b/sbt-mode-comint.el
@@ -27,12 +27,12 @@ as the comint-input-ring on console start-up"
   :type 'string
   :group 'sbt)
 
-(defcustom sbt:sbt-prompt-regexp "^\\(\\[[^\]]*\\] \\)?[>$][ ]*"
+(defcustom sbt:sbt-prompt-regexp "^\\(sbt:[^>]+\\)?>[ ]+"
   "A regular expression to match sbt REPL prompt"
   :type 'string
   :group 'sbt)
 
-(defcustom sbt:console-prompt-regexp "^scala>[ ]*"
+(defcustom sbt:console-prompt-regexp "^scala>[ ]+"
   "A regular expression to match scala REPL prompt"
   :type 'string
   :group 'sbt)
@@ -42,8 +42,8 @@ as the comint-input-ring on console start-up"
   :type 'string
   :group 'sbt)
 
-(defcustom sbt:prompt-regexp "^\\(\\(scala\\|\\[[^\]]*\\] \\)?[>$]\\|[ ]+|\\)[ ]*"
-  "A regular expression to match sbt and scala console prompts"
+(defcustom sbt:prompt-regexp "^\\(\\(sbt:[^>]+\\)?\\|scala\\)>[ ]+"
+  "A regular expression to match sbt and scala console prompts. The prompt MUST NOT match \"^[completions].*\"."
   :type 'string
   :group 'sbt)
 
@@ -185,15 +185,14 @@ what `sbt:move-marker-before-prompt-filter` did."
 (defun sbt:scala-escape-string (str)
   (mapconcat 'sbt:scala-escape-char str ""))
 
-(defconst sbt:completions-regex "^\\[completions\\] \\(.*\\)?$")
+(defconst sbt:completions-regex "^\\[completions\\] \\(.*?\\)?$")
 (defconst sbt:repl-completions-string
   ;; waiting for better times... maybe some day we will have a completions command in
   ;; the scala-console
-  (concat "{ val input = \"$1\"; "
-          "val completer = new scala.tools.nsc.interpreter.JLineCompletion($intp).completer; "
-          "val completions = completer.complete(input, input.length); "
-          "val prefix = input.substring(0, completions.cursor); "
-          "completions.candidates.foreach(c => println(\"[completions] \" + c))} // completions")
+  (concat "new scala.tools.nsc.interpreter.PresentationCompilerCompleter($intp)."
+          "complete(\"$1\", \"$1\".length).candidates."
+          "foreach(c => println(s\"[completions] $c\"))"
+          " // completions")
   "A command to send to scala console to get completions for $1 (an escaped string).")
 
 (defun sbt:get-sbt-completions (input)


### PR DESCRIPTION
… work for 2.13

This effectively reverts 8da22bf543788001a7d5cd62449a674ced0d2c0c by @markus1189, which
made the prompt regexp accept the magic [completions] string as the beginning of a prompt,
which -- together with a completion such as > -- broke the completion functionality.

Fixes #133, #125, #117